### PR TITLE
Upgrade to bullseye

### DIFF
--- a/deployments/docker/indexer.Dockerfile
+++ b/deployments/docker/indexer.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS=debian:bullseye-slim
-ARG GOLANG_VERSION=1.17-bullseye
+ARG GOLANG_VERSION=1.19-bullseye
 ARG CGO=0
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/deployments/docker/replayer.Dockerfile
+++ b/deployments/docker/replayer.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS=debian:bullseye-slim
-ARG GOLANG_VERSION=1.17-bullseye
+ARG GOLANG_VERSION=1.19-bullseye
 ARG CGO=0
 ARG GOOS=linux
 ARG GOARCH=x64


### PR DESCRIPTION
### Description
Ticket: GslmL-2022911
- Upgrade to `go1.19` on Debian `bullseye` in Dockerfile(s)